### PR TITLE
docs: add igly.ai to design tools

### DIFF
--- a/src/content/en/tools/design.md
+++ b/src/content/en/tools/design.md
@@ -30,3 +30,4 @@ date: "2026-05-10"
 | 18 | [Bolt.new](https://bolt.new) | Free/$50/mo | Full-stack prototyping | Generate complete web apps in one prompt |
 | 19 | [Uizard](https://uizard.io) | Free/$12/mo | Wireframe to design | Turn hand-drawn sketches into UI designs |
 | 20 | [Visily](https://visily.ai) | Free | Screenshot to design | Convert screenshots to editable designs |
+| 21 | [igly.ai](https://igly.ai) | Free credits | AI image editing | Background removal, inpainting, upscaling, and generative fill |

--- a/src/content/tools/design.md
+++ b/src/content/tools/design.md
@@ -30,3 +30,4 @@ date: "2026-05-10"
 | 18 | [Bolt.new](https://bolt.new) | 免费/$50/月 | 全栈原型 | 一句话生成完整 Web 应用原型 |
 | 19 | [Uizard](https://uizard.io) | 免费/$12/月 | 线框图转设计 | 手绘草图秒变 UI 设计稿 |
 | 20 | [Visily](https://visily.ai) | 免费 | 截图转设计 | 把截图变成可编辑的设计稿 |
+| 21 | [igly.ai](https://igly.ai) | 免费积分 | AI 图像编辑 | 背景移除、局部重绘、图像放大和生成式填充 |


### PR DESCRIPTION
Adds igly.ai (https://igly.ai) to the Design tools list in both English and Chinese content. igly.ai provides AI image editing for background removal, inpainting, upscaling, and generative fill.\n\nDemo/reference: https://www.youtube.com/watch?v=HB2E1WZ12is\n\nValidation: npm run build